### PR TITLE
Changing doctrine-extensions dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "~2.1|~3.0",
-        "gedmo/doctrine-extensions": "^2.3.1"
+        "gedmo/doctrine-extensions": "dev-master"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "to use the ORM extensions",


### PR DESCRIPTION
Depending on master branch of doctrine-extensions since PR #1525 has not been released yet
